### PR TITLE
Fix EU cookie consent issue (GitHub #44)

### DIFF
--- a/backend/app/services/rss_parser.py
+++ b/backend/app/services/rss_parser.py
@@ -10,7 +10,7 @@ from typing import List, Optional
 from pydantic import BaseModel
 from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
 
-from .youtube_utils import get_rss_url, get_video_url, extract_channel_id, HTTP_HEADERS
+from .youtube_utils import get_rss_url, get_video_url, extract_channel_id, HTTP_HEADERS, YOUTUBE_COOKIES
 from .shorts_detector import is_short_from_video_info
 
 
@@ -56,7 +56,12 @@ async def fetch_channel_info(channel_id: str, timeout: float = 10.0) -> ChannelI
     """
     rss_url = get_rss_url(channel_id)
     
-    async with httpx.AsyncClient(timeout=timeout, follow_redirects=True, headers=HTTP_HEADERS) as client:
+    async with httpx.AsyncClient(
+        timeout=timeout,
+        follow_redirects=True,
+        headers=HTTP_HEADERS,
+        cookies=YOUTUBE_COOKIES
+    ) as client:
         response = await client.get(rss_url)
         response.raise_for_status()
         
@@ -117,7 +122,12 @@ async def fetch_videos(rss_url: str, limit: int = 15, timeout: float = 10.0) -> 
     Raises:
         ValueError: If RSS feed cannot be parsed
     """
-    async with httpx.AsyncClient(timeout=timeout, follow_redirects=True, headers=HTTP_HEADERS) as client:
+    async with httpx.AsyncClient(
+        timeout=timeout,
+        follow_redirects=True,
+        headers=HTTP_HEADERS,
+        cookies=YOUTUBE_COOKIES
+    ) as client:
         response = await client.get(rss_url)
         response.raise_for_status()
         

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -7,3 +7,4 @@
 # Testing frameworks
 pytest==7.4.4
 pytest-asyncio==0.23.3
+pytest-mock==3.12.0


### PR DESCRIPTION
- Add YOUTUBE_COOKIES with SOCS/CONSENT cookies to bypass EU consent redirects
- Update HTTP_HEADERS with browser-like User-Agent and Accept-Language
- Add consent page detection with clear error messages
- Update RSS feed fetching to use consent cookies
- Add pytest-mock for testing
- Add tests for consent cookie handling and detection

The SOCS cookie signals that consent has already been given, which is the same approach used by yt-dlp and other YouTube tools. This allows EU users to add channels via @handle URLs without hitting the consent redirect.